### PR TITLE
Hide inventory count support

### DIFF
--- a/space/SUMMARY.md
+++ b/space/SUMMARY.md
@@ -40,6 +40,7 @@
   * [Custom fields](guides/products/custom-fields.md)
   * [Content drawers](guides/products/content-drawers.md)
   * [Hide out of stock options](guides/products/hide-out-of-stock-variants.md)
+  * [Hide inventory count](guides/products/hide-inventory-count.md)
 * [Collections](guides/collections/README.md)
   * [Customize filters](guides/collections/collection-filters.md)
   * [Tag filtering](guides/collections/collection-tag-filtering.md)

--- a/space/guides/products/hide-inventory-count.md
+++ b/space/guides/products/hide-inventory-count.md
@@ -1,0 +1,35 @@
+# Hide inventory count
+
+Use Space theme settings to hide stock count badges on product cards.
+
+***
+
+### Hide stock count on product cards
+
+{% stepper %}
+{% step %}
+Go to **Online Store** > **Themes** > **Customize**.
+{% endstep %}
+
+{% step %}
+Click **Theme settings** (gear icon).
+{% endstep %}
+
+{% step %}
+Open **Product cards**.
+{% endstep %}
+
+{% step %}
+Set **Stock threshold** to `0` (or leave it blank).
+{% endstep %}
+
+{% step %}
+Click **Save**.
+{% endstep %}
+{% endstepper %}
+
+***
+
+### Important
+
+This controls stock count badges shown on product cards. It does not control the inventory block on the product page, which uses the **Inventory threshold** setting in product section blocks.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a new support document for the Space theme explaining how to hide inventory count by setting the product card stock threshold to 0 or blank.

<div><a href="https://cursor.com/agents/bc-cdc53ac3-0b33-478e-8b67-a0451963e4ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdc53ac3-0b33-478e-8b67-a0451963e4ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->