### PR TITLE
📝 Weekly Doc Gaps — Week of May 11, 2026

### DIFF
--- a/keystone/guides/products/recently-viewed-behavior.md
+++ b/keystone/guides/products/recently-viewed-behavior.md
@@ -1,0 +1,26 @@
+---
+title: Recently Viewed — Behavior with Hidden and Out-of-Stock Products
+description: Auto-generated stub — needs content
+status: draft
+created: 2026-05-11
+source: weekly-gap-analysis
+---
+
+## Overview
+
+> ⚠️ This page was auto-generated from support ticket analysis. It needs to be written.
+
+**Why this doc is needed:**
+A customer discovered that products hidden using the "hidden" tag still appear in the Recently Viewed section with the Add to Cart button and price visible. The existing recently-viewed.md section doc does not address this behavior. A related question about customizing out-of-stock variant text ("Sold Out") was also raised.
+
+**Topics to cover:**
+- How the Recently Viewed section stores and displays browsed products (browser session/localStorage)
+- Known limitation: the "hidden" tag hides products from collections/search but NOT from the Recently Viewed component
+- How to suppress hidden products from appearing in Recently Viewed (custom Liquid or CSS workaround)
+- How to configure out-of-stock variant display text (e.g., changing "Unavailable" to "Sold Out")
+- Where to find the sold-out label setting in theme settings vs section settings
+- Limitations of the Recently Viewed section (no server-side filtering)
+
+**Related tickets (Week of May 11, 2026):**
+- #81841952 — Anurag Jayasawal (Keystone): "Hidden product still appears in Recently Viewed with Add to Cart and price visible"
+- #81841952 — Anurag Jayasawal: "Can we change out-of-stock variant text to 'Sold Out'?"

--- a/keystone/guides/sitewide/search-page-filters.md
+++ b/keystone/guides/sitewide/search-page-filters.md
@@ -1,0 +1,26 @@
+---
+title: Search Page Filter Layouts (Side vs Top)
+description: Auto-generated stub — needs content
+status: draft
+created: 2026-05-11
+source: weekly-gap-analysis
+---
+
+## Overview
+
+> ⚠️ This page was auto-generated from support ticket analysis. It needs to be written.
+
+**Why this doc is needed:**
+A customer reported that the Search Grid's filter sidebar does not appear when the "Side" layout is selected (only "Top" works), affecting both modified and unmodified Keystone v2.1.0 themes. No dedicated doc explains search page filter configuration, the difference between Side and Top layouts, or known limitations.
+
+**Topics to cover:**
+- How to access and configure the Search Grid section in Keystone
+- Explanation of the "Side" vs "Top" filter layout options
+- How to verify filters are enabled and configured in Shopify's Search & Discovery settings
+- Known issue: filter sidebar (Side layout) may not display in v2.1.0 — workaround or fix steps
+- How to check if the issue is theme-specific or app-related (Shopify Search & Discovery app)
+- Screenshots of both Side and Top layouts showing expected behavior
+- Troubleshooting steps if filters aren't showing
+
+**Related tickets (Week of May 11, 2026):**
+- #97734993 — Laura (Keystone v2.1.0): "Search Grid filters are not showing when SIDE is selected. They show when TOP is selected."

--- a/space/getting-started/importing-the-demo-layout.md
+++ b/space/getting-started/importing-the-demo-layout.md
@@ -1,0 +1,25 @@
+---
+title: Getting Started with the Demo Layout
+description: Auto-generated stub — needs content
+status: draft
+created: 2026-05-11
+source: weekly-gap-analysis
+---
+
+## Overview
+
+> ⚠️ This page was auto-generated from support ticket analysis. It needs to be written.
+
+**Why this doc is needed:**
+Pre-purchase and new customers frequently expect to "import" the Shopify Theme Store demo layout directly into their store. There is no doc explaining what the demo represents, how theme presets work, or how to replicate the demo's visual style as a starting point.
+
+**Topics to cover:**
+- What the Shopify Theme Store demo actually is (a curated preset with sample content, not an importable layout)
+- How to apply a theme style/preset on install
+- How to use the demo as a visual reference and recreate sections manually
+- Using the theme editor to build out your home page using the same sections shown in the demo
+- Where to find demo-specific section configurations in the docs
+- What content/images need to be replaced after applying a preset
+
+**Related tickets (Week of May 11, 2026):**
+- #96207640 — Malik: "Is it possible to import the exact demo layout directly into my store as a starting point?"

--- a/space/guides/navigation/megamenu-and-dropdown-layouts.md
+++ b/space/guides/navigation/megamenu-and-dropdown-layouts.md
@@ -1,0 +1,26 @@
+---
+title: Megamenu and Dropdown Navigation Layouts
+description: Auto-generated stub — needs content
+status: draft
+created: 2026-05-11
+source: weekly-gap-analysis
+---
+
+## Overview
+
+> ⚠️ This page was auto-generated from support ticket analysis. It needs to be written.
+
+**Why this doc is needed:**
+Multiple customers have asked about megamenu-style dropdown navigation in Space, often expecting feature parity with the Paper theme. Space's current navigation docs don't explain what dropdown styles are available or how they compare to Paper.
+
+**Topics to cover:**
+- What dropdown navigation options are available in Space (multi-column, image dropdowns)
+- How to create the closest equivalent to a megamenu using Space's fixed-menu and menu-drawer sections
+- Feature parity clarification: what navigation features are in Paper but not Space
+- Step-by-step guide for configuring a multi-column dropdown (if achievable via settings or custom CSS)
+- Workarounds and advanced customization options for customers needing megamenu-like layouts
+- Links to fixed-menu.md, menu-drawer.md, and navigation-slider.md
+
+**Related tickets (Week of May 11, 2026):**
+- #98615815 — Nick Kelly: "Some basic functionality in Paper isn't in Space — the complete lack of megamenus in Space"
+- #95049730 — Pooja Patel (Keystone): Dropdown layout customization / layout matching reference


### PR DESCRIPTION
## Documentation Gap Report — Week of May 11, 2026

> Analysis based on 7 closed support tickets (May 4–11, 2026) across Keystone and Space themes.

---

### Missing Documentation

- **Space — Megamenu / Advanced Navigation Layouts**: Two separate tickets (#98615815, #95049730) raised questions about megamenu-style dropdown navigation. Space's existing navigation docs (fixed-menu, menu-drawer, navigation-slider) don't explain what mega-nav options are available or how to create multi-column dropdowns. There's also no doc clarifying the feature parity difference between Space and Paper for megamenus.

- **Space — Importing the Demo Layout (Onboarding Starter)**: Ticket #96207640 reveals a pre-purchase customer expectation gap — users assume the Shopify Theme Store demo layout can be imported directly. No doc explains what "demo" means in the Shopify context (demo styles are theme presets, not importable page layouts), how to apply theme presets, or how to get started building a layout close to the demo.

- **Keystone — Search Page: Filter Sidebar (Side Layout) Configuration**: Ticket #97734993 surfaced a bug/behavior issue where the Side filter layout on the Search page doesn't display filters. No dedicated doc exists explaining search page filter layout options (Side vs Top), how to configure them, and known limitations. The `search-results.md` guide exists but may not cover search-specific filter layout settings.

- **Keystone & Space — Recently Viewed: Behavior with Hidden Products**: Ticket #81841952 reveals that hidden-tagged products still appear in the Recently Viewed section with Add to Cart active. The `recently-viewed.md` section doc exists but almost certainly doesn't cover this edge case or how to suppress hidden products from the component.

---

### Incomplete Documentation

- **`keystone/sections/sitewide/announcement.md` / `space/sections/sitewide/announcement.md`**: Ticket #92747922 describes an announcement bar that bounces/flickers during slow scrolling. The existing announcement section docs likely cover basic configuration but do not address scroll-triggered show/hide behavior, known interaction quirks, or workarounds for the bounce effect. Needs a troubleshooting note or known behavior section.

- **`keystone/sections/sitewide/cart-drawer.md`**: Ticket #98238364 shows the cart icon count badge doesn't update after removing items without a page refresh. The cart-drawer doc likely covers configuration options but not this live-count sync behavior. Needs clarification on expected behavior and/or a known issues note for v2.1.x.

- **`keystone/sections/products-and-collections/recently-viewed.md`**: The existing doc likely documents section settings but not the hidden product edge case (#81841952) or how hidden-tagged products interact with the recently-viewed cache. Needs a "Limitations & Known Behavior" section.

- **`space/sections/navigation/` (all nav docs)**: Ticket #98615815 shows Space customers expect megamenu functionality. The existing navigation docs don't set expectations about what's NOT available in Space vs Paper. Each nav section doc should note feature limitations and link to an explanation of the Space navigation model.

---

### Suggested New Pages

- **`space/guides/navigation/megamenu-and-dropdown-layouts.md`**: Explain what dropdown navigation styles are available in Space, how multi-column dropdowns can be achieved (if at all), and explicitly address the parity difference with Paper. Include links to the fixed-menu and menu-drawer docs.

- **`space/getting-started/importing-the-demo-layout.md`**: Explain what the Shopify theme store demo represents (preset styles + sample content), how to apply a theme style/preset, and how to replicate the demo layout. Clarify that demo page layouts cannot be "imported" but the visual style can be matched.

- **`keystone/guides/sitewide/search-page-filters.md`**: Document the Search Grid section's filter layout options (Top vs Side), how to enable/configure each, and known limitations (e.g., Side layout display issues in v2.1.0). Include screenshots.

- **`keystone/sections/sitewide/cart-drawer.md` update** *(or known issues entry)*: Document the cart icon count live-update behavior and note the refresh requirement bug present in certain versions.

- **`keystone/guides/products/recently-viewed-behavior.md`**: Document how the Recently Viewed section works, what products appear (including hidden-tagged products), and how to configure or work around the inclusion of hidden products.

---

*Generated automatically from weekly Intercom ticket analysis on 2026-05-11.*

---

## Stub Files Created in This PR

| File | Topic |
|------|-------|
| `space/guides/navigation/megamenu-and-dropdown-layouts.md` | Space megamenu / advanced dropdown navigation |
| `space/getting-started/importing-the-demo-layout.md` | How to start from the Shopify demo layout |
| `keystone/guides/sitewide/search-page-filters.md` | Keystone search page filter sidebar (Side vs Top) |
| `keystone/guides/products/recently-viewed-behavior.md` | Recently Viewed section: hidden products & sold-out variants |

Each stub includes a brief "why this doc is needed" summary, a list of topics to cover, and references to the support tickets that surfaced the gap. Assign a writer to each stub to fill in the full content.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/brickspacelab/docs/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->