### PR TITLE
BL-623: Add Paper developer primer for Shopify newcomers

### DIFF
--- a/paper/SUMMARY.md
+++ b/paper/SUMMARY.md
@@ -6,6 +6,7 @@
 ## Getting started
 
 * [Theme basics](getting-started/theme-basics.md)
+* [Start with Paper when you are new to Shopify](getting-started/paper-and-shopify-for-developers.md)
 * [Theme settings](getting-started/theme-settings/README.md)
   * [Colors](getting-started/theme-settings/colors.md)
   * [Typography](getting-started/theme-settings/typography.md)

--- a/paper/getting-started/paper-and-shopify-for-developers.md
+++ b/paper/getting-started/paper-and-shopify-for-developers.md
@@ -1,0 +1,38 @@
+# Start with Paper when you are new to Shopify
+
+Paper is a Shopify Online Store 2.0 theme. If your background is in stacks such as ASP.NET, Ruby on Rails, or Laravel, the biggest mental shift is that **merchants** customize almost everything in the **theme editor**, while **Liquid** templates render HTML on Shopify’s servers instead of your own application server.
+
+## What Shopify owns versus what you own
+
+* **Shopify** hosts the storefront, checkout, cart, customer accounts, and the admin where merchants manage products, collections, and settings.
+* **Themes** are a bundle of Liquid files, JSON templates, CSS, and JavaScript that Shopify serves when someone visits a URL on the storefront.
+* **Apps** extend the admin or inject blocks into the theme. They are not npm packages inside the theme by default.
+
+You do not SSH into a server to deploy Paper. You upload or connect the theme through the Shopify admin or Shopify GitHub integration, then publish when ready.
+
+## What Liquid is (and is not)
+
+* Liquid is a **templating language**, not a general-purpose programming language. It loops over objects Shopify provides (for example `product`, `collection`, `cart`).
+* Business logic that must stay secret belongs in a **private app** or Shopify Function, not in theme JavaScript exposed to the browser.
+* Paper’s sections and blocks map closely to what you see in **Online Store** > **Themes** > **Customize**. That is intentional so merchants can iterate without deployments.
+
+## Where Paper’s documentation lives
+
+* **Product walkthroughs:** continue with [Theme basics](theme-basics.md) inside this Paper hub for editor-first setup tasks.
+* **Deep dives:** browse the GitBook sidebar for **Guides**, **Sections**, and **Advanced customizations** once you know which surface you are changing.
+* **Cross-theme articles:** the [Brickspace general hub](../../general/README.md) covers licensing, support policy, and comparisons between Paper, Space, Keystone, and Slab.
+
+## Purchasing and installing Paper
+
+Buy Paper through the [Shopify Theme Store](https://themes.shopify.com/) listing for Brickspace Lab. After purchase, the theme appears in **Online Store** > **Themes** > **Theme library**. Duplicate it before large experiments so you always have a clean rollback.
+
+## Suggested learning order
+
+1. Skim Shopify’s [Themes overview](https://shopify.dev/docs/storefronts/themes) and [Liquid introduction](https://shopify.dev/docs/api/liquid).
+2. Follow [Theme basics](theme-basics.md) to configure global settings in Paper.
+3. Read [Use custom templates](../guides/basics/use-custom-templates.md) when you need alternate layouts for specific collections or products.
+4. Open [Add custom Liquid](../advanced-customizations/adding-custom-liquid/README.md) only after you are comfortable making backups and working in **Edit code**.
+
+## When to hire help
+
+Brickspace support answers questions about built-in features. It does not replace a Shopify Partner for bespoke app integration or large refactors. The general hub lists [Hire a Shopify developer](../../general/support/hire-a-shopify-developer.md) if you need a retained developer.

--- a/paper/getting-started/theme-basics.md
+++ b/paper/getting-started/theme-basics.md
@@ -5,6 +5,10 @@ If you need additional support contact our team for personalized onboarding, and
 {% endhint %}
 
 {% hint style="info" %}
+Coming from traditional web development (for example .NET or Rails)? Read [Start with Paper when you are new to Shopify](paper-and-shopify-for-developers.md) for how Liquid, the theme editor, and Shopify hosting fit together before you dive into sections and blocks.
+{% endhint %}
+
+{% hint style="info" %}
 Not sure which theme is right for your business? Our detailed [comparison chart](https://help.brickspacelab.com/general/theme-comparisons) breaks down key features available in each of our themes.
 {% endhint %}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses **BL-623** gap 6 (“Paper for developers from non-Shopify backgrounds”) with a short onboarding article and discovery links from **Theme basics**.

## Changes

- **Start with Paper when you are new to Shopify** — Explains Shopify vs self-hosted responsibilities, Liquid’s role, where Paper docs and the general hub live, Theme Store purchase flow, a suggested reading order with official Shopify dev links, and when to engage a Partner.
- **Theme basics** — Adds a hint pointing developers to the new primer before the comparison-chart hint.

## Linear

BL-623 (gap 6).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [BL-623](https://linear.app/brickspacelab/issue/BL-623/docs-gap-report-week-of-may-6-2026)

<div><a href="https://cursor.com/agents/bc-073eaab7-ff3b-48f3-a048-0bff39b8c511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-073eaab7-ff3b-48f3-a048-0bff39b8c511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

